### PR TITLE
Potential fix for code scanning alert no. 518: Prototype-polluting assignment

### DIFF
--- a/src/services/wasm/wasm.ts
+++ b/src/services/wasm/wasm.ts
@@ -945,7 +945,7 @@ function writeScopePath(
       continue;
     }
 
-    const next: Record<string, unknown> = {};
+    const next = Object.create(null) as Record<string, unknown>;
 
     current[key] = next;
     current = next;


### PR DESCRIPTION
Potential fix for [https://github.com/angular-wave/angular.ts/security/code-scanning/518](https://github.com/angular-wave/angular.ts/security/code-scanning/518)

Use prototype-less objects for intermediate nodes in `writeScopePath` so attacker-influenced path traversal/writes cannot interact with `Object.prototype` even if future validation regresses or edge cases appear.

Best targeted fix in `src/services/wasm/wasm.ts`:
- In `writeScopePath`, replace `const next: Record<string, unknown> = {};` with a prototype-less object created via `Object.create(null)`.
- Keep current behavior and API unchanged.
- No new imports or dependencies are required.

This preserves functionality (dot-path creation and assignment) while making path-created containers resilient to prototype pollution.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
