### PR TITLE
fix(wasm): harden scope path writes

### DIFF
--- a/dist/services/wasm/wasm.js
+++ b/dist/services/wasm/wasm.js
@@ -1,4 +1,4 @@
-import { isNumber, instantiateWasm, deleteProperty } from '../../shared/utils.js';
+import { isNumber, instantiateWasm, deleteProperty, isProxy } from '../../shared/utils.js';
 
 const WASM_SCOPE_IMPORT_NAMESPACE = "angular_ts";
 const textEncoder = new TextEncoder();
@@ -487,11 +487,15 @@ function writeScopePath(scope, path, value) {
             current = existing;
             continue;
         }
-        const next = {};
-        current[key] = next;
+        const next = Object.create(null);
+        if (!writeSafeScopeProperty(current, key, next)) {
+            return false;
+        }
         current = next;
     }
-    current[keys[keys.length - 1]] = value;
+    if (!writeSafeScopeProperty(current, keys[keys.length - 1], value)) {
+        return false;
+    }
     return true;
 }
 function deleteScopePath(scope, path) {
@@ -513,7 +517,25 @@ function scopePathKeys(path) {
     return path.split(".").filter(Boolean);
 }
 function isSafeScopePath(keys) {
-    return keys.every((key) => !UNSAFE_SCOPE_PATH_KEYS.has(key));
+    return keys.every((key) => !isUnsafeScopePathKey(key));
+}
+function isUnsafeScopePathKey(key) {
+    return UNSAFE_SCOPE_PATH_KEYS.has(key);
+}
+function writeSafeScopeProperty(target, key, value) {
+    if (isUnsafeScopePathKey(key)) {
+        return false;
+    }
+    if (isProxy(target)) {
+        return target.$handler.set(target.$target, key, value, target);
+    }
+    Object.defineProperty(target, key, {
+        configurable: true,
+        enumerable: true,
+        value,
+        writable: true,
+    });
+    return true;
 }
 
 export { WasmProvider, WasmScope, WasmScopeAbi };

--- a/src/services/wasm/wasm.ts
+++ b/src/services/wasm/wasm.ts
@@ -2,6 +2,7 @@ import {
   deleteProperty,
   instantiateWasm,
   isNumber,
+  isProxy,
 } from "../../shared/utils.ts";
 
 const WASM_SCOPE_IMPORT_NAMESPACE = "angular_ts";
@@ -947,11 +948,15 @@ function writeScopePath(
 
     const next = Object.create(null) as Record<string, unknown>;
 
-    current[key] = next;
+    if (!writeSafeScopeProperty(current, key, next)) {
+      return false;
+    }
     current = next;
   }
 
-  current[keys[keys.length - 1]] = value;
+  if (!writeSafeScopeProperty(current, keys[keys.length - 1], value)) {
+    return false;
+  }
 
   return true;
 }
@@ -983,5 +988,32 @@ function scopePathKeys(path: string): string[] {
 }
 
 function isSafeScopePath(keys: string[]): boolean {
-  return keys.every((key) => !UNSAFE_SCOPE_PATH_KEYS.has(key));
+  return keys.every((key) => !isUnsafeScopePathKey(key));
+}
+
+function isUnsafeScopePathKey(key: string): boolean {
+  return UNSAFE_SCOPE_PATH_KEYS.has(key);
+}
+
+function writeSafeScopeProperty(
+  target: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): boolean {
+  if (isUnsafeScopePathKey(key)) {
+    return false;
+  }
+
+  if (isProxy(target)) {
+    return target.$handler.set(target.$target, key, value, target);
+  }
+
+  Object.defineProperty(target, key, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+
+  return true;
 }


### PR DESCRIPTION
## Summary

- harden Wasm scope path writes with a guarded write boundary
- preserve AngularTS scope proxy reactivity by routing proxy writes through the scope handler
- mirror the fix into tracked `dist/services/wasm/wasm.js` so CodeQL alerts in built output are addressed too

This is intended to cover CodeQL prototype-polluting assignment alerts #515, #516, #517, and #518.

## Verification

- `make lint` passes
- `npx playwright test src/services/wasm/wasm.test.ts --reporter=line` passes
- `make check` is currently blocked on current master by Dart generated binding validation reporting stale generated bindings (`make -C integrations/dart generate`), before reaching WASM-specific checks
